### PR TITLE
Update splitter.js

### DIFF
--- a/js/splitter.js
+++ b/js/splitter.js
@@ -123,7 +123,7 @@ angular.module('bgDirectives', [])
                         return $(element).is(':visible');
                     },
                     function() {
-                        if($(element).is(':visible')) loadSavedPosition();
+                        if($(element).is(':visible')) $timeout(loadSavedPosition());
                     });
             }
         };


### PR DESCRIPTION
This fixes a problem I'm seeing with the saved off sizes. If the parent is visible, but not fully laid out, then the splitter pane sets the top pane's size too small based on the no yet done layout. Just adding a $timeout fixes this problem.
